### PR TITLE
[fix/#19] merge 페이지 파트 수정사항 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,8 @@
         "html2canvas": "^1.4.1",
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",
+        "react-dnd": "^16.0.1",
+        "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^18.2.0",
         "react-pro-sidebar": "^1.0.0",
         "react-redux": "^8.0.5",
@@ -3530,6 +3532,21 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@react-dnd/asap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A=="
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw=="
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA=="
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
@@ -6990,6 +7007,16 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+    },
+    "node_modules/dnd-core": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+      "dependencies": {
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
+      }
     },
     "node_modules/dns-equal": {
       "version": "1.0.0",
@@ -14772,6 +14799,43 @@
         "node": ">=8"
       }
     },
+    "node_modules/react-dnd": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
+      "dependencies": {
+        "dnd-core": "^16.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -20237,6 +20301,21 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
       "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw=="
     },
+    "@react-dnd/asap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A=="
+    },
+    "@react-dnd/invariant": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw=="
+    },
+    "@react-dnd/shallowequal": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA=="
+    },
     "@reduxjs/toolkit": {
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
@@ -22818,6 +22897,16 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+    },
+    "dnd-core": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+      "requires": {
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
+      }
     },
     "dns-equal": {
       "version": "1.0.0",
@@ -28273,6 +28362,26 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "react-dnd": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
+      "requires": {
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      }
+    },
+    "react-dnd-html5-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
+      "requires": {
+        "dnd-core": "^16.0.1"
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "html2canvas": "^1.4.1",
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.2.0",
     "react-pro-sidebar": "^1.0.0",
     "react-redux": "^8.0.5",

--- a/src/components/common/box/fileMergeBox/fileMergeBox.tsx
+++ b/src/components/common/box/fileMergeBox/fileMergeBox.tsx
@@ -1,16 +1,24 @@
-import { Box } from "@mui/material";
-import React from "react";
-import { ChangeEvent, createContext, useContext, useCallback, useRef, useState, useEffect} from "react";
-import UploadButton from "../../button/uploadButton/uploadButton";
-import RefreshButton from "../../button/refreshButton/refreshButton";
-import FileBox from "../fileBox/fileBox";
-import FileMergeSelectBox from "../fileMergeSelectBox/fileMergeSelectBox"
-import DeleteButton from "../../button/deleteButton/deleteButton";
-import { Upload } from "../../../content/upload/upload";
-import { RootState } from "../../../../stores/store";
-import { useSelector } from "react-redux";
-import axios from "axios";
-
+import { Box } from '@mui/material';
+import React from 'react';
+import {
+  ChangeEvent,
+  createContext,
+  useContext,
+  useCallback,
+  useRef,
+  useState,
+  useEffect,
+} from 'react';
+import UploadButton from '../../button/uploadButton/uploadButton';
+import RefreshButton from '../../button/refreshButton/refreshButton';
+import FileBox from '../fileBox/fileBox';
+import FileMergeSelectBox from '../fileMergeSelectBox/fileMergeSelectBox';
+import DeleteButton from '../../button/deleteButton/deleteButton';
+import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
+import { Upload } from '../../../content/upload/upload';
+import { RootState } from '../../../../stores/store';
+import { useSelector } from 'react-redux';
+import axios from 'axios';
 
 type NewType = {
   id: number; //파일들의 고유값 id
@@ -19,24 +27,24 @@ type NewType = {
   name: string;
 };
 
-type IFileTypes = NewType; 
+type IFileTypes = NewType;
 
 type IFileList = {
   imageFiles: IFileTypes[];
-}
+};
 
-interface mergeResponse{
+interface mergeResponse {
   status: number;
   code: string;
   message: string;
   data: mergeInfos;
 }
 
-interface mergeInfos{
+interface mergeInfos {
   mergeResourceInfos: resourcesData[];
 }
 
-interface resourcesData{
+interface resourcesData {
   resources: resource[];
 }
 
@@ -52,72 +60,63 @@ interface FileObjectType {
   object: File;
   URL: string;
   name: string;
-};
+}
 
 interface FileUploadBoxProps {
   onFilesChange: (files: FileObjectType[]) => void;
-  
-};
-
-
-
-
-
-interface UploadButtonProps {
-  onUpload: (files : FileList | null) => void;
 }
 
+interface UploadButtonProps {
+  onUpload: (files: FileList | null) => void;
+}
 
-export default function FileMergeBox({ onFilesChange } : FileUploadBoxProps) {
+export default function FileMergeBox({ onFilesChange }: FileUploadBoxProps) {
   const [currentMainFile, setCurrentMainFile] = useState<File | null>(null);
-  const fileId = useRef<number>(0)
+  const fileId = useRef<number>(0);
   const [mergeObjects, setMergeObjects] = useState<resourcesData[]>([]);
   const fetchedFiles = useRef<File[]>([]);
   const [fileobjects, setFileObjects] = useState<FileObjectType[]>([]);
 
-  let uuid = useSelector((state:RootState) => {
-    return state.branch.uuid
-  })
+  let uuid = useSelector((state: RootState) => {
+    return state.branch.uuid;
+  });
 
   useEffect(() => {
     const fetchMergeData = async () => {
       try {
-        const response = await axios.get<mergeResponse>('/api/v1/branches/'+ uuid +'/merge');
-        console.log("merge data 불러오기 성공");
-        console.log("merge data: ", response.data.data.mergeResourceInfos);
+        const response = await axios.get<mergeResponse>(
+          '/api/v1/branches/' + uuid + '/merge'
+        );
+        console.log('merge data 불러오기 성공');
+        console.log('merge data: ', response.data.data.mergeResourceInfos);
         setMergeObjects(response.data.data.mergeResourceInfos);
-        console.log("저장된 mergeData : " , mergeObjects)
+        console.log('저장된 mergeData : ', mergeObjects);
       } catch (error) {
-        console.log("log history 불러오기 실패");
+        console.log('log history 불러오기 실패');
         console.log(error);
       }
     };
-  
+
     fetchMergeData();
   }, [uuid]);
-
 
   const handleMainFileUpdate = (file: File | null) => {
     // mainfile 상태 업데이트 처리
     //console.log("Main file(fileMergeBox.tsx): ", file);
     setCurrentMainFile(file);
-    console.log("저장된 Main file(fileMergeBox)", currentMainFile);
+    console.log('저장된 Main file(fileMergeBox)', currentMainFile);
   };
-
-  
 
   var reversed_index;
 
   const fileList: IFileList = {
-    imageFiles: fileobjects
-  }
+    imageFiles: fileobjects,
+  };
 
   //파일 오브젝트 추출
-  const files: File[] = fileList.imageFiles.map((file) => file.object)
+  const files: File[] = fileList.imageFiles.map((file) => file.object);
 
-  
   //handleFilterFile => id 일치 여부를 확인해 필터링
-  
 
   // const handleFilterFile = useCallback(
   //   (id: number): void => {
@@ -129,37 +128,36 @@ export default function FileMergeBox({ onFilesChange } : FileUploadBoxProps) {
   //   [fileobjects, onFilesChange]
   // );
 
-
-
-  console.log("업로드 파일 목록", fileobjects)
-  
   const handleSubmit = (event: any) => {
     event.preventDefault();
-  };  
+  };
 
-
-
-  
   // fetchedFiles 배열에 저장된 파일 데이터 사용 가능
-  console.log("fetch된 파일 데이터:", fetchedFiles);
+  console.log('fetch된 파일 데이터:', fetchedFiles);
 
   useEffect(() => {
     const updatedFileObjects = [...fileobjects]; // fileObjects 배열을 복사하여 업데이트에 사용
-    console.log("선언 직후의 updatedFileObjects(fileMergeBox.tsx) : ", updatedFileObjects);
+    console.log(
+      '선언 직후의 updatedFileObjects(fileMergeBox.tsx) : ',
+      updatedFileObjects
+    );
     let fileid = 0;
-    
-    console.log("currentMainFile 값 : ", currentMainFile)
-    
+
+    console.log('currentMainFile 값 : ', currentMainFile);
 
     mergeObjects.map(async (resources: any, index) => {
       try {
         const response = await fetch(resources.fileLink);
         const blobData = await response.blob();
-        const file = new File([blobData], resources.fileName, { type: "image/png" });
-        
+        const file = new File([blobData], resources.fileName, {
+          type: 'image/png',
+        });
+
         // 현재의 currentMainFile이 기존 파일 객체를 대체해야 하는지 확인
         if (currentMainFile != null) {
-          const index = updatedFileObjects.findIndex((resource: FileObjectType) => resource.name === currentMainFile.name);
+          const index = updatedFileObjects.findIndex(
+            (resource: FileObjectType) => resource.name === currentMainFile.name
+          );
           if (index !== -1) {
             updatedFileObjects[index] = {
               ...updatedFileObjects[index],
@@ -167,9 +165,7 @@ export default function FileMergeBox({ onFilesChange } : FileUploadBoxProps) {
               URL: URL.createObjectURL(currentMainFile),
             };
           }
-        }
-
-        else{
+        } else {
           await updatedFileObjects.push({
             id: index++,
             object: file,
@@ -177,15 +173,14 @@ export default function FileMergeBox({ onFilesChange } : FileUploadBoxProps) {
             name: resources.fileName,
           });
         }
-        
-        
+
         // 상태를 업데이트
         setFileObjects(updatedFileObjects);
         onFilesChange(updatedFileObjects);
-        console.log("main이 적용된 updatedFileObjects: ", updatedFileObjects);
+        console.log('main이 적용된 updatedFileObjects: ', updatedFileObjects);
       } catch (error) {
         // 오류 처리
-        console.log("mergeObjects 처리 오류 발생");
+        console.log('mergeObjects 처리 오류 발생');
         console.log(error);
       }
     });
@@ -193,111 +188,192 @@ export default function FileMergeBox({ onFilesChange } : FileUploadBoxProps) {
 
   //console.log("카피한 fileObjects(fileMergeBox.tsx) : ", copyFileObjects);
 
+  /*------------- 리스트 드래그 앤 드랍 관련 함수 ------------*/
 
+  const onDragEnd = (result: any) => {
+    if (!result.destination) {
+      return;
+    }
 
-/*------------- 리스트 드래그 앤 드랍 관련 함수 ------------*/
-const onDragEnd = (result: any) => {
-  if(!result.destination){
-    return;
-  }
+    const { source, destination } = result;
+    // //let lists = [...fileobjects];
+    // let lists = [...fileobjects];
+    // let index;
+    // let mergeLists = [...mergeObjects];
 
-  const { source, destination } = result;
-  let lists = [...fileobjects];
-  let index;
+    // console.log('드래그앤드롭 이전 리스트', lists);
 
-  console.log(lists)
+    // if (source.index !== destination.index) {
+    //   let selectItem = lists[result.source.index];
+    //   lists.splice(result.source.index, 1);
+    //   lists.splice(destination.index, 0, selectItem);
+    //   setFileObjects(lists);
+    //   onFilesChange(lists);
+    //   console.log('드래그 앤 드롭 이후  리스트 :', fileobjects);
 
-  if(source.index !== destination.index){
-    let selectItem = lists[result.source.index];
-    lists.splice(result.source.index, 1);
-    lists.splice(destination.index, 0, selectItem);
-    setFileObjects(lists);
-    onFilesChange(lists);
-    console.log(lists)
-  }
+    //   let selectMergeItem = mergeLists[result.source.index];
+    //   mergeLists.splice(result.source.index, 1);
+    //   mergeLists.splice(destination.index, 0, selectMergeItem);
+    //   setMergeObjects(mergeLists);
+    //   console.log('드래그 앤 드롭 이후 mergeObjects:', mergeLists);
+    // }
 
-};
+    // mergeObjects 배열의 순서 업데이트
+    let updatedMergeObjects = Array.from(mergeObjects);
+    const [removed] = updatedMergeObjects.splice(source.index, 1);
+    updatedMergeObjects.splice(destination.index, 0, removed);
+    setMergeObjects(updatedMergeObjects);
 
+    // 업데이트된 mergeObjects 배열을 사용하여 fileobjects 업데이트
+    const updatedFileObjects = updatedMergeObjects.map(
+      (resources: any, index) => {
+        // 기존에 존재하는 파일인 경우 업데이트
+        const existingFile = fileobjects.find(
+          (file: FileObjectType) => file.name === resources.fileName
+        );
+        if (existingFile) {
+          return { ...existingFile, id: index };
+        }
+        // 새로운 파일인 경우 추가
+        return {
+          id: index,
+          object: new File([], resources.fileName),
+          URL: '',
+          name: resources.fileName,
+        };
+      }
+    );
+    setFileObjects(updatedFileObjects);
+    onFilesChange(updatedFileObjects);
+  };
 
-/*------------- 리스트 드래그 앤 드랍 관련 함수 ------------*/
+  /*------------- 리스트 드래그 앤 드랍 관련 함수 ------------*/
 
-
-
-
+  console.log('업로드 파일 목록', fileobjects);
 
   return (
-    <Box width="100%" maxWidth="500px" minWidth="300px">
-      <Box display="flex" justifyContent="space-between" alignItems="center">
-        <Box width="56px"></Box>
+    <Box width='100%' maxWidth='500px' minWidth='300px'>
+      <Box display='flex' justifyContent='space-between' alignItems='center'>
+        <Box width='56px'></Box>
         <Box>uploaded files</Box>
-        <Box display="flex">
-        
+        <Box display='flex'>
           <RefreshButton />
         </Box>
       </Box>
-      
-      
 
-      <Box
-        sx={{
-          height: "400px",
-          borderRadius: "3px",
-          boxShadow: 1,
-          backgroundColor: "#F0F0F0",
-          overflow: "auto",
-        }}
-        >
-        <Box
-          display="flex"
-          className="DragDrop-Files"
-          flexWrap="wrap"
-          sx={{
-            py: 6,
-            gap: "10px",
-            flexDirection: "column",
-            alignItems: "center",
-          }}
-        >
-          {mergeObjects.length > 0 &&
-            mergeObjects.map((resources: any, index) => {
-              if(resources.duplicated === true){
-                return(
-                  <FileMergeSelectBox text={resources.fileName} backgroundColor="#FFFFD2" fileLink={resources.fileLink} onMainFileUpdate={handleMainFileUpdate}>
-                    {/* <Box onClick={() => handleFilterFile(index)}>
-                      <DeleteButton/>
-                    </Box> */}
-                  </FileMergeSelectBox>
-                );
-              }
-
-              else if(resources.duplicated === false 
-                && resources.new === true){
-                  return(
-                    <FileMergeSelectBox text={resources.fileName} backgroundColor="#BEFBFF" fileLink={''} onMainFileUpdate={()=>{}}>
-                      {/* <Box onClick={() => handleFilterFile(index)}>
-                        <DeleteButton/>
-                      </Box> */}
-                    </FileMergeSelectBox>
-                  );
-              }
-
-              else{
-
-                return(
-                  <Box >
-                    <FileBox text={resources.fileName}>
-                    {/* <Box onClick={() => handleFilterFile(index)}>
-                      <DeleteButton/>
-                    </Box> */}
-                    </FileBox>
-                  </Box>
-                );
-              }
-            })
-          }
-          
-        </Box>
-      </Box>
+      <DragDropContext onDragEnd={onDragEnd}>
+        <Droppable droppableId='MergeDragDrop'>
+          {(provided) => (
+            <Box
+              sx={{
+                height: '400px',
+                borderRadius: '3px',
+                boxShadow: 1,
+                backgroundColor: '#F0F0F0',
+                overflow: 'auto',
+              }}
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+            >
+              <Box
+                display='flex'
+                className='MergeDragDrop'
+                flexWrap='wrap'
+                sx={{
+                  py: 6,
+                  gap: '10px',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                }}
+              >
+                {mergeObjects.length > 0 &&
+                  mergeObjects.map((resources: any, index) => {
+                    if (resources.duplicated === true) {
+                      return (
+                        <Draggable
+                          draggableId={index.toString()}
+                          index={index}
+                          key={resources.fileName}
+                        >
+                          {(provided) => (
+                            <Box
+                              ref={provided.innerRef}
+                              {...provided.draggableProps}
+                              {...provided.dragHandleProps}
+                            >
+                              <FileMergeSelectBox
+                                text={resources.fileName}
+                                backgroundColor='#FFFFD2'
+                                fileLink={resources.fileLink}
+                                onMainFileUpdate={handleMainFileUpdate}
+                              >
+                                {/* <Box onClick={() => handleFilterFile(index)}>
+                                <DeleteButton/>
+                              </Box> */}
+                              </FileMergeSelectBox>
+                            </Box>
+                          )}
+                        </Draggable>
+                      );
+                    } else if (
+                      resources.duplicated === false &&
+                      resources.new === true
+                    ) {
+                      return (
+                        <Draggable
+                          draggableId={index.toString()}
+                          index={index}
+                          key={resources.fileName}
+                        >
+                          {(provided) => (
+                            <Box
+                              ref={provided.innerRef}
+                              {...provided.draggableProps}
+                              {...provided.dragHandleProps}
+                            >
+                              <FileMergeSelectBox
+                                text={resources.fileName}
+                                backgroundColor='#BEFBFF'
+                                fileLink={''}
+                                onMainFileUpdate={() => {}}
+                              >
+                                {/* <Box onClick={() => handleFilterFile(index)}>
+                                <DeleteButton/>
+                                </Box> */}
+                              </FileMergeSelectBox>
+                            </Box>
+                          )}
+                        </Draggable>
+                      );
+                    } else {
+                      return (
+                        <Draggable
+                          draggableId={index.toString()}
+                          index={index}
+                          key={resources.fileName}
+                        >
+                          {(provided) => (
+                            <Box
+                              ref={provided.innerRef}
+                              {...provided.draggableProps}
+                              {...provided.dragHandleProps}
+                            >
+                              <FileBox text={resources.fileName}>
+                                {/* <Box onClick={() => handleFilterFile(index)}>
+                                  <DeleteButton/>
+                                </Box> */}
+                              </FileBox>
+                            </Box>
+                          )}
+                        </Draggable>
+                      );
+                    }
+                  })}
+              </Box>
+            </Box>
+          )}
+        </Droppable>
+      </DragDropContext>
     </Box>
   );
 }

--- a/src/components/common/box/fileMergeBox/fileMergeBox.tsx
+++ b/src/components/common/box/fileMergeBox/fileMergeBox.tsx
@@ -243,6 +243,8 @@ export default function FileMergeBox({ onFilesChange }: FileUploadBoxProps) {
         };
       }
     );
+
+    console.log('onDragEnd 후 fileobjects: ', updatedFileObjects);
     setFileObjects(updatedFileObjects);
     onFilesChange(updatedFileObjects);
   };

--- a/src/components/common/box/fileMergeBox/fileMergeBox.tsx
+++ b/src/components/common/box/fileMergeBox/fileMergeBox.tsx
@@ -291,7 +291,7 @@ export default function FileMergeBox({ onFilesChange }: FileUploadBoxProps) {
                     if (resources.duplicated === true) {
                       return (
                         <Draggable
-                          draggableId={index.toString()}
+                          draggableId={resources.fileName}
                           index={index}
                           key={resources.fileName}
                         >
@@ -321,7 +321,7 @@ export default function FileMergeBox({ onFilesChange }: FileUploadBoxProps) {
                     ) {
                       return (
                         <Draggable
-                          draggableId={index.toString()}
+                          draggableId={resources.fileName}
                           index={index}
                           key={resources.fileName}
                         >
@@ -348,7 +348,7 @@ export default function FileMergeBox({ onFilesChange }: FileUploadBoxProps) {
                     } else {
                       return (
                         <Draggable
-                          draggableId={index.toString()}
+                          draggableId={resources.fileName}
                           index={index}
                           key={resources.fileName}
                         >

--- a/src/components/common/box/fileMergeBox/fileMergeBox.tsx
+++ b/src/components/common/box/fileMergeBox/fileMergeBox.tsx
@@ -195,7 +195,31 @@ export default function FileMergeBox({ onFilesChange } : FileUploadBoxProps) {
 
 
 
+/*------------- 리스트 드래그 앤 드랍 관련 함수 ------------*/
+const onDragEnd = (result: any) => {
+  if(!result.destination){
+    return;
+  }
 
+  const { source, destination } = result;
+  let lists = [...fileobjects];
+  let index;
+
+  console.log(lists)
+
+  if(source.index !== destination.index){
+    let selectItem = lists[result.source.index];
+    lists.splice(result.source.index, 1);
+    lists.splice(destination.index, 0, selectItem);
+    setFileObjects(lists);
+    onFilesChange(lists);
+    console.log(lists)
+  }
+
+};
+
+
+/*------------- 리스트 드래그 앤 드랍 관련 함수 ------------*/
 
 
 

--- a/src/components/common/box/fileMergeSelectBox/fileMergeSelectBox.tsx
+++ b/src/components/common/box/fileMergeSelectBox/fileMergeSelectBox.tsx
@@ -1,12 +1,22 @@
-import { Box, Button, Typography, IconButton, Modal, Radio, RadioGroup, FormControlLabel, FormControl, FormLabel } from "@mui/material";
-import React from "react";
+import {
+  Box,
+  Button,
+  Typography,
+  IconButton,
+  Modal,
+  Radio,
+  RadioGroup,
+  FormControlLabel,
+  FormControl,
+  FormLabel,
+} from '@mui/material';
+import React from 'react';
 import ErrorIcon from '@mui/icons-material/Error';
 import CheckIcon from '@mui/icons-material/Check';
 import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
-import axios from "axios";
-import { useSelector } from "react-redux";
-import { RootState } from "../../../../stores/store";
-
+import axios from 'axios';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../../stores/store';
 
 const style = {
   position: 'absolute' as 'absolute',
@@ -21,82 +31,86 @@ const style = {
   p: 4,
 };
 
-
-interface duplicateResponse{
+interface duplicateResponse {
   status: number;
   code: string;
   message: string;
   data: string;
 }
 
-export default function FileMergeSelectBox(props: { children: React.ReactNode, text: string, backgroundColor: string, fileLink: string, onMainFileUpdate: (file: File | null) => void}) {
-  const { children, text, backgroundColor, fileLink,  } = props;
+export default function FileMergeSelectBox(props: {
+  children: React.ReactNode;
+  text: string;
+  backgroundColor: string;
+  fileLink: string;
+  onMainFileUpdate: (file: File | null) => void;
+}) {
+  const { children, text, backgroundColor, fileLink } = props;
   const [open, setOpen] = React.useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
-  const [duplicateData, setDuplicateData] = React.useState(''); 
+  const [duplicateData, setDuplicateData] = React.useState('');
 
   const [mainfile, setMainFile] = React.useState<File | null>(null);
   const [isConfirmed, setIsConfirmed] = React.useState(false);
 
   let projectUuid = useSelector((state: RootState) => {
-    return state.project.uuid; 
-  })
+    return state.project.uuid;
+  });
 
   React.useEffect(() => {
     (async () => {
-      await axios.get<duplicateResponse>('/api/v1/projects/'+ projectUuid +'/main/resources/' + text)
-      .then((response)=> {
-        console.log("특정 메인 리소스 데이터 불러오기 성공");
-        console.log("특정 메인 리소스 데이터 : ", response.data.data);
-        setDuplicateData(response.data.data)
-        
-      })
-      .catch((error)=>{
-        console.log("특정 메인 리소스 데이터 불러오기 실패");
-        console.log(error);
-      })
+      await axios
+        .get<duplicateResponse>(
+          '/api/v1/projects/' + projectUuid + '/main/resources/' + text
+        )
+        .then((response) => {
+          console.log('특정 메인 리소스 데이터 불러오기 성공');
+          console.log('특정 메인 리소스 데이터 : ', response.data.data);
+          setDuplicateData(response.data.data);
+        })
+        .catch((error) => {
+          console.log('특정 메인 리소스 데이터 불러오기 실패');
+          console.log(error);
+        });
     })();
-    
   }, [projectUuid]);
 
-  
-  console.log("파일 링크 왔냐?(merge)", fileLink);
+  console.log('파일 링크 왔냐?(merge)', fileLink);
 
-  const [selectedValue, setSelectedValue] = React.useState("main");
+  const [selectedValue, setSelectedValue] = React.useState('main');
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSelectedValue(event.target.value);
   };
 
-  const handleConfirm = () => {
-    if (selectedValue === "main") {
+  const handleConfirm = async () => {
+    if (selectedValue === 'main') {
       // 'main'이 선택된 경우 처리할 이벤트
-      console.log("main이 선택되었습니다.");
-      
-      fetch(duplicateData)
-      .then((response) => {
-        return response.blob()
-      }).then((blobData) => {
-        const mainfile = new File([blobData], text ,{ type: "image/png" });
-        console.log(mainfile);
-        setMainFile(mainfile);
-        setIsConfirmed(true);
-        handleClose();
-      })
-      .catch((error) => {
-        console.log(error);
-      })
+      console.log('main이 선택되었습니다.');
 
-    } else if (selectedValue === "branchimg") {
+      await fetch(duplicateData)
+        .then((response) => {
+          return response.blob();
+        })
+        .then((blobData) => {
+          const mainfile = new File([blobData], text, { type: 'image/png' });
+          console.log(mainfile);
+          setMainFile(mainfile);
+          setIsConfirmed(true);
+          handleClose();
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    } else if (selectedValue === 'branchimg') {
       // 'branchimg'가 선택된 경우 처리할 이벤트
-      console.log("current branch가 선택되었습니다.");
+      console.log('current branch가 선택되었습니다.');
       setMainFile(null);
       setIsConfirmed(true);
       handleClose();
     }
   };
-
 
   // mainfile 상태를 상위 컴포넌트로 전달
   React.useEffect(() => {
@@ -105,108 +119,149 @@ export default function FileMergeSelectBox(props: { children: React.ReactNode, t
 
   return (
     <Box
-      display="flex"
+      display='flex'
       sx={{
-        width: "440px",
-        height: "40px",
-        borderRadius: "3px",
+        width: '440px',
+        height: '40px',
+        borderRadius: '3px',
         boxShadow: 1,
         backgroundColor: backgroundColor,
-        alignItems: "center",
+        alignItems: 'center',
       }}
-    > 
-    
-      {backgroundColor === "#FFFFD2" && (
+    >
+      {backgroundColor === '#FFFFD2' && (
         <Box>
           {isConfirmed ? ( // isConfirmed 상태에 따라 아이콘을 조건부로 렌더링
             <IconButton disabled>
-              <CheckCircleRoundedIcon sx={{color: "#7adb4a"}}/>
+              <CheckCircleRoundedIcon sx={{ color: '#7adb4a' }} />
             </IconButton>
           ) : (
-            <IconButton onClick={handleOpen} aria-label="error">
+            <IconButton onClick={handleOpen} aria-label='error'>
               <ErrorIcon />
             </IconButton>
           )}
           <Modal
-          open={open}
-          onClose={handleClose}
-          aria-labelledby="modal-modal-title"
-          aria-describedby="modal-modal-description"
+            open={open}
+            onClose={handleClose}
+            aria-labelledby='modal-modal-title'
+            aria-describedby='modal-modal-description'
           >
             <Box sx={style}>
-              <Box sx = {{
-                display: "flex",
-                flexDirection: 'column',
-                justifyItems: 'center',
-                alignItems: 'center'
-              }}>
-              
-              <Box sx = {{
-                display: "flex",
-                flexDirection: 'column',
-                justifyItems: 'center',
-                alignItems: 'center',
-                marginBottom: 1
-              }}>
-                <FormControl>
-                  <RadioGroup
-                    row
-                    aria-labelledby="demo-form-control-label-placement"
-                    name="position"
-                    value={selectedValue}
-                    onChange={handleChange}
-                  >
-                    <FormControlLabel
-                      value="main"
-                      control={<Radio />}
-                      label={
-                        <Box sx = {{
-                          display: "flex",
-                          flexDirection: 'column',
-                          justifyItems: 'center',
-                          alignItems: 'center'
-                        }}>
-                          <Typography sx={{marginBottom: 1}} id="modal-modal-title" variant="h6" component="h2">
-                            main
-                          </Typography>
-                          <img style={{maxWidth: '300px', maxHeight: '300px', border: '1px solid #F0F0F0'}} src={duplicateData} alt="Image"/>
-                        </Box>
-                      }
-                      labelPlacement="top"
-                    />
-                    
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyItems: 'center',
+                  alignItems: 'center',
+                }}
+              >
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyItems: 'center',
+                    alignItems: 'center',
+                    marginBottom: 1,
+                  }}
+                >
+                  <FormControl>
+                    <RadioGroup
+                      row
+                      aria-labelledby='demo-form-control-label-placement'
+                      name='position'
+                      value={selectedValue}
+                      onChange={handleChange}
+                    >
+                      <FormControlLabel
+                        value='main'
+                        control={<Radio />}
+                        label={
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              flexDirection: 'column',
+                              justifyItems: 'center',
+                              alignItems: 'center',
+                            }}
+                          >
+                            <Typography
+                              sx={{ marginBottom: 1 }}
+                              id='modal-modal-title'
+                              variant='h6'
+                              component='h2'
+                            >
+                              main
+                            </Typography>
+                            <img
+                              style={{
+                                maxWidth: '300px',
+                                maxHeight: '300px',
+                                border: '1px solid #F0F0F0',
+                              }}
+                              src={duplicateData}
+                              alt='Image'
+                            />
+                          </Box>
+                        }
+                        labelPlacement='top'
+                      />
 
-                    <FormControlLabel
-                      value="branchimg"
-                      control={<Radio />}
-                      label={
-                      <Box sx = {{
-                        display: "flex",
-                        flexDirection: 'column',
-                        justifyItems: 'center',
-                        alignItems: 'center'
-                      }}>
-                        <Typography sx={{marginBottom: 1}} id="modal-modal-title" variant="h6" component="h2">
-                          current branch
-                        </Typography>
-                        <img style={{maxWidth: '300px', maxHeight: '300px', border: '1px solid #F0F0F0'}} src={fileLink} alt="Image"/>
-                      </Box>
-                      }
-                      labelPlacement="top"
-                    />
-                  </RadioGroup>
-                </FormControl>
-              </Box>
-              <Button variant="outlined" startIcon={<CheckIcon />} onClick={handleConfirm}>
-                confirm
-              </Button>
+                      <FormControlLabel
+                        value='branchimg'
+                        control={<Radio />}
+                        label={
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              flexDirection: 'column',
+                              justifyItems: 'center',
+                              alignItems: 'center',
+                            }}
+                          >
+                            <Typography
+                              sx={{ marginBottom: 1 }}
+                              id='modal-modal-title'
+                              variant='h6'
+                              component='h2'
+                            >
+                              current branch
+                            </Typography>
+                            <img
+                              style={{
+                                maxWidth: '300px',
+                                maxHeight: '300px',
+                                border: '1px solid #F0F0F0',
+                              }}
+                              src={fileLink}
+                              alt='Image'
+                            />
+                          </Box>
+                        }
+                        labelPlacement='top'
+                      />
+                    </RadioGroup>
+                  </FormControl>
+                </Box>
+                <Button
+                  variant='outlined'
+                  startIcon={<CheckIcon />}
+                  onClick={handleConfirm}
+                >
+                  confirm
+                </Button>
               </Box>
             </Box>
           </Modal>
         </Box>
       )}
 
-      <Typography style={{ overflow: "hidden", textOverflow: "ellipsis", paddingLeft: "10px" }}>
+      <Typography
+        style={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          paddingLeft: '10px',
+        }}
+      >
         {text}
       </Typography>
       {children}

--- a/src/components/common/box/fileMergeSelectBox/fileMergeSelectBox.tsx
+++ b/src/components/common/box/fileMergeSelectBox/fileMergeSelectBox.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Typography, IconButton, Modal, Radio, RadioGroup, FormCont
 import React from "react";
 import ErrorIcon from '@mui/icons-material/Error';
 import CheckIcon from '@mui/icons-material/Check';
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded';
 import axios from "axios";
 import { useSelector } from "react-redux";
 import { RootState } from "../../../../stores/store";
@@ -36,7 +37,7 @@ export default function FileMergeSelectBox(props: { children: React.ReactNode, t
   const [duplicateData, setDuplicateData] = React.useState(''); 
 
   const [mainfile, setMainFile] = React.useState<File | null>(null);
-
+  const [isConfirmed, setIsConfirmed] = React.useState(false);
 
   let projectUuid = useSelector((state: RootState) => {
     return state.project.uuid; 
@@ -80,6 +81,7 @@ export default function FileMergeSelectBox(props: { children: React.ReactNode, t
         const mainfile = new File([blobData], text ,{ type: "image/png" });
         console.log(mainfile);
         setMainFile(mainfile);
+        setIsConfirmed(true);
         handleClose();
       })
       .catch((error) => {
@@ -90,6 +92,7 @@ export default function FileMergeSelectBox(props: { children: React.ReactNode, t
       // 'branchimg'가 선택된 경우 처리할 이벤트
       console.log("current branch가 선택되었습니다.");
       setMainFile(null);
+      setIsConfirmed(true);
       handleClose();
     }
   };
@@ -115,9 +118,15 @@ export default function FileMergeSelectBox(props: { children: React.ReactNode, t
     
       {backgroundColor === "#FFFFD2" && (
         <Box>
-          <IconButton onClick={handleOpen} aria-label="error">
-            <ErrorIcon/>
-          </IconButton>
+          {isConfirmed ? ( // isConfirmed 상태에 따라 아이콘을 조건부로 렌더링
+            <IconButton disabled>
+              <CheckCircleRoundedIcon sx={{color: "#7adb4a"}}/>
+            </IconButton>
+          ) : (
+            <IconButton onClick={handleOpen} aria-label="error">
+              <ErrorIcon />
+            </IconButton>
+          )}
           <Modal
           open={open}
           onClose={handleClose}

--- a/src/components/content/merge/merge.tsx
+++ b/src/components/content/merge/merge.tsx
@@ -1,14 +1,14 @@
-import { Box } from "@mui/material";
-import React, { useEffect, useState } from "react";
-import BranchButton from "../../common/button/branchButton";
-import PreviewBox from "../../common/box/previewBox/previewBox";
-import TextBox from "../../common/box/textBox/textBox";
-import TitleBox from "../../common/box/titleBox/titleBox";
-import FileMergeBox from "../../common/box/fileMergeBox";
-import axios from "axios";
-import { useSelector } from "react-redux";
-import { RootState } from "../../../stores/store";
-import { useNavigate } from "react-router-dom";
+import { Box } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import BranchButton from '../../common/button/branchButton';
+import PreviewBox from '../../common/box/previewBox/previewBox';
+import TextBox from '../../common/box/textBox/textBox';
+import TitleBox from '../../common/box/titleBox/titleBox';
+import FileMergeBox from '../../common/box/fileMergeBox';
+import axios from 'axios';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../stores/store';
+import { useNavigate } from 'react-router-dom';
 
 interface branchResponse {
   status: number;
@@ -19,7 +19,7 @@ interface branchResponse {
 
 interface branchData {
   branchId: number;
-  branchName: string; 
+  branchName: string;
 }
 
 interface FileObjectType {
@@ -29,7 +29,7 @@ interface FileObjectType {
   name: string;
 }
 
-interface PreviewType{
+interface PreviewType {
   url: string;
 }
 
@@ -39,80 +39,98 @@ export default function Merge() {
   const [imgFile, setImgFile] = useState<Blob | null>(null);
 
   const handleFilesChange = async (files: FileObjectType[]) => {
-    await console.log("merge로 온 파일은 여기! : ", files)
-    const updatedFileObjects = [...files].sort((a,b) => a.id - b.id);
-    await setFileObjects(updatedFileObjects)
-    await setFileObjects(updatedFileObjects)
-  }
+    await console.log('merge로 온 파일은 여기! : ', files);
+    const updatedFileObjects = [...files].sort((a, b) => a.id - b.id);
 
+    const uniqueIds = Array.from(new Set(files.map((file) => file.id)));
+    const uniqueUpdatedFileObjects = uniqueIds
+      .map((id) => files.find((file) => file.id === id))
+      .filter((file) => file !== undefined) as FileObjectType[];
+
+    await console.log(
+      '중복되지 않는 파일 객체 배열: ',
+      uniqueUpdatedFileObjects
+    );
+
+    await setFileObjects(uniqueUpdatedFileObjects);
+    //await setFileObjects(updatedFileObjects);
+  };
 
   const handlePreviewChange = async (previewImg: PreviewType) => {
-    await console.log("merge url 여기! : ",previewImg.url);
+    await console.log('merge url 여기! : ', previewImg.url);
     await setPreviewImage(previewImg.url);
   };
 
   const handleImgFileChange = async (file: Blob | null) => {
     await setImgFile(file);
-    await console.log("merge 이미지 파일 여기! : ", imgFile);
-  }
+    await console.log('merge 이미지 파일 여기! : ', imgFile);
+  };
 
-  let uuid = useSelector((state:RootState) => {
-    return state.branch.uuid
-  })
+  let uuid = useSelector((state: RootState) => {
+    return state.branch.uuid;
+  });
 
   const navigate = useNavigate();
   const projectNavigate = () => {
-    navigate("/project")
-  }
+    navigate('/project');
+  };
 
   useEffect(() => {
     (async () => {
-      await axios.get<branchResponse>('/api/v1/branches/'+ uuid)
-      .then((response)=> {
-        console.log("단일로그 불러오기 성공");
-        console.log("단일로그 데이터 : ", response.data.data.branchName);
-        if(response.data.data.branchName === "main") {
-          alert("main 브랜치에서는 머지할 수 없습니다");
-          projectNavigate();
-        }
-      })
-      .catch((error)=>{
-        console.log("단일로그 불러오기 실패");
-        console.log(error);
-      })
+      await axios
+        .get<branchResponse>('/api/v1/branches/' + uuid)
+        .then((response) => {
+          console.log('단일로그 불러오기 성공');
+          console.log('단일로그 데이터 : ', response.data.data.branchName);
+          if (response.data.data.branchName === 'main') {
+            alert('main 브랜치에서는 머지할 수 없습니다');
+            projectNavigate();
+          }
+        })
+        .catch((error) => {
+          console.log('단일로그 불러오기 실패');
+          console.log(error);
+        });
     })();
-    
   }, [uuid]);
 
-
-  return(
-    <Box display="block">
-      <Box sx={{ px: 5, py: 3, alignItems: "center" }}>
+  return (
+    <Box display='block'>
+      <Box sx={{ px: 5, py: 3, alignItems: 'center' }}>
         <BranchButton />
       </Box>
 
       <Box
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
+        display='flex'
+        flexDirection='column'
+        alignItems='center'
         sx={{ rowGap: 5, mx: 20, py: 5, pt: 0 }}
       >
-        <TitleBox content="MERGE" />
+        <TitleBox content='MERGE' />
 
         <Box
-          width="1"
-          display="flex"
-          justifyContent="center"
-          gap={"16px"}
-          flexWrap="wrap"
+          width='1'
+          display='flex'
+          justifyContent='center'
+          gap={'16px'}
+          flexWrap='wrap'
         >
-          <PreviewBox fileobjects={fileobjects} currentLogObjects="" onPreviewChange={handlePreviewChange} onImgFileChange={handleImgFileChange}/>
-          <FileMergeBox onFilesChange={handleFilesChange}/>
+          <PreviewBox
+            fileobjects={fileobjects}
+            currentLogObjects=''
+            onPreviewChange={handlePreviewChange}
+            onImgFileChange={handleImgFileChange}
+          />
+          <FileMergeBox onFilesChange={handleFilesChange} />
         </Box>
         <Box>
-          <TextBox fileobjects={fileobjects} url={previewImage} imgFile={imgFile}/>
+          <TextBox
+            fileobjects={fileobjects}
+            url={previewImage}
+            imgFile={imgFile}
+          />
         </Box>
       </Box>
     </Box>
   );
-};
+}

--- a/src/components/content/project/project.tsx
+++ b/src/components/content/project/project.tsx
@@ -92,7 +92,7 @@ interface BranchesData{
 interface Branch{
   branchName: string;
   branchUuid: string;
-  branchId: string; 
+  branchId: number; 
 }
 
 export default function Project() {
@@ -130,20 +130,12 @@ export default function Project() {
             console.log("브랜치 정보 불러오기 성공");
             console.log("가져온 데이터", response.data.data.projectBranchInfos);
             setBranchData(response.data.data.projectBranchInfos);
-            
-            branchData.map((branches) => {
-              if(branches.branchName === 'main'){
-                dispatch(setMainBranchId(branches.branchId.toString()));
-                dispatch(setMainBranchUuid(branches.branchUuid));
-
-              }
-            })
         })
         .catch((error)=>{
             console.log(error);
         })
     })();
-  }, []);
+  }, [projectUuid]);
 
   useEffect(() => {
     (async () => {
@@ -164,8 +156,6 @@ export default function Project() {
     })();
   }, [projectUuid]);
 
-  console.log("mainbranchId: ", mainId);
-  console.log("mainbranchUuid : ", mainUuid);
 
   
   useEffect(() => {
@@ -214,6 +204,15 @@ export default function Project() {
   const [createTime, setCreateTime] = useState('');
   const [nickname, setNickname] = useState('');
 
+  branchData.map((branchData) => {
+    if(branchData.branchName === 'main'){
+      dispatch(setMainBranchId(branchData.branchId.toString()));
+      console.log("mainbranchId: ", mainId);
+      dispatch(setMainBranchUuid(branchData.branchUuid));
+      console.log("mainbranchUuid : ", mainUuid);
+
+    }
+  })
 
   return (
     <Box display="block">


### PR DESCRIPTION
수정사항

1. 머지할 때 현재 위치한 프로젝트의 메인 브랜치 ID값 제대로 받아와서 반영할 수 있도록 수정
2. 중복 merge일 때, main의 이미지 선택 시 fetch가 안 되는 문제 수정
3. 중복 merge일 때 이미지 선택 완료하고 버튼 디자인 선택 완료로 변경 및 클릭 비활성화
4. merge 페이지에서도 드래그 앤 드롭 가능하도록 수정
 